### PR TITLE
chore: Cache the reek configuration loading for faster execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [CHANGE] Bump aruba, fakefs, minitest, mocha, reek, rubocop dependencies (by [@faisal][])
 * [CHANGE] Add .solargraph.yml config file to enable Solargraph LSP use in editors such as BBedit (by [@faisal][])
 * [CHANGE] Drop support for Ruby 2.7.x, 3.0.x (by [@faisal][])
+* [CHANGE] Cache the reek configuration loading for faster execution (by [@raff-s][])
 
 # v4.9.1 / 2024-04-14 [(commits)](https://github.com/whitesmith/rubycritic/compare/v4.9.0...v4.9.1)
 
@@ -454,3 +455,4 @@
 [@Fito]: https://github.com/Fito
 [@fbuys]: https://github.com/fbuys
 [@exoego]: https://github.com/exoego
+[@raff-s]: https://github.com/raff-s

--- a/lib/rubycritic/analysers/helpers/reek.rb
+++ b/lib/rubycritic/analysers/helpers/reek.rb
@@ -4,8 +4,12 @@ require 'reek'
 
 module RubyCritic
   class Reek < ::Reek::Examiner
+    def self.configuration
+      @configuration ||= ::Reek::Configuration::AppConfiguration.from_default_path
+    end
+
     def initialize(analysed_module)
-      super(analysed_module, configuration: ::Reek::Configuration::AppConfiguration.from_default_path)
+      super(analysed_module, configuration: self.class.configuration)
     end
   end
 end


### PR DESCRIPTION
PR https://github.com/whitesmith/rubycritic/pull/510
## What
- Update the `RubyCritic::Reek` class to cache the result of loading the Reek app configuration.
## Why?
Performing this operation is computationally expensive and significantly impacts execution speed. The performance impact becomes particularly noticeable when your reek configuration contains multiple `directories` configurations.
### Steps to reproduce
Generate some ruby files
```sh
#!/bin/bash

output_dir="./ruby_files"
mkdir -p "$output_dir"

for i in $(seq 1 100); do
  filename="$output_dir/file$i.rb"

  ruby_content="#!/usr/bin/env ruby
    class MyClass$i
      def initialize(name)
        @name = name
      end

      def greet
        puts \"Hello, \#{@name}! This is MyClass$i speaking.\"
      end
    end

    instance = MyClass$i.new('World')
    instance.greet"

  echo "$ruby_content" >"$filename"
done
```
Configure `.reek.yml`
```yml
detectors:
  # Allow utility functions, but only as private methods
  UtilityFunction:
    enabled: true
    public_methods_only: true

  TooManyStatements:
    enabled: true
    max_statements: 8

  IrresponsibleModule:
    enabled: false

  UncommunicativeModuleName:
    accept:
      - V2
      - V3

  DuplicateMethodCall:
    max_calls: 4

directories:
  "foo/bar":
    IrresponsibleModule:
      enabled: false
    NestedIterators:
      max_allowed_nesting: 2
    UnusedPrivateMethod:
      enabled: false
    InstanceVariableAssumption:
      enabled: false
  "foo/bar/baz":
    IrresponsibleModule:
      enabled: false
    UtilityFunction:
      enabled: false

exclude_paths:
  - spec
```
`.rubycritic.yml`
```yml
threshold_score: 0
no_browser: true
formats:
  - html
minimum_score: 89
paths:
  - 'ruby_files'
```
Update the `analysers_runner.rb` to only run reek
```rb
module RubyCritic
  class AnalysersRunner
    ANALYSERS = [
      Analyser::ReekSmells,
    ].freeze
...
```
**Master branch**
```sh
time bundle exec rubycritic
bundle exec rubycritic  6.07s user 0.31s system 95% cpu 6.702 total
```
**This branch**
```sh
 time bundle exec rubycritic
bundle exec rubycritic  0.65s user 0.29s system 65% cpu 1.433 total
```
In one of the projects I'm working on this change allows rubycritic to run in ~6min instead of ~17min in CI.

Check list:
- [ ] Add an entry to the [changelog](https://github.com/whitesmith/rubycritic/blob/main/CHANGELOG.md)
- [ ] [Squash all commits into a single one](https://github.com/whitesmith/rubycritic/blob/main/CONTRIBUTING.md)
- [ ] Describe your PR, link issues, etc.
